### PR TITLE
Allow specifying the ONNX export opset version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ For faster inference, export the detection model to an optimized FP16 TensorRT e
 ```bash
 retinanet export model.pth engine.plan
 ```
+Note: for more recent versions of TensorRT the ONNX opset version should be specified (using `--opset 9` for instance).
 
-Evaluat the model with TensorRT backend on [COCO 2017](http://cocodataset.org/#download):
+Evaluate the model with TensorRT backend on [COCO 2017](http://cocodataset.org/#download):
 ```bash
 retinanet infer engine.plan --images /coco/images/val2017/ --annotations /coco/annotations/instances_val2017.json
 ```

--- a/retinanet/main.py
+++ b/retinanet/main.py
@@ -64,6 +64,7 @@ def parse(args):
     parser_export.add_argument('--batch', metavar='size', type=int, help='max batch size to use for TensorRT engine', default=2)
     parser_export.add_argument('--full-precision', help='export in full instead of half precision', action='store_true')
     parser_export.add_argument('--int8', help='calibrate model and export in int8 precision', action='store_true')
+    parser_export.add_argument('--opset', metavar='version', type=int, help='ONNX opset version')
     parser_export.add_argument('--calibration-batches', metavar='size', type=int, help='number of batches to use for int8 calibration', default=10)
     parser_export.add_argument('--calibration-images', metavar='path', type=str, help='path to calibration images to use for int8 calibration', default="")
     parser_export.add_argument('--calibration-table', metavar='path', type=str, help='path of existing calibration table to load from, or name of new calibration table', default="")
@@ -160,7 +161,7 @@ def worker(rank, args, world, model, state):
         elif not args.full_precision:
             precision = "FP16"
 
-        exported = model.export(input_size, args.batch, precision, calibration_files, args.calibration_table, args.verbose, onnx_only=onnx_only)
+        exported = model.export(input_size, args.batch, precision, calibration_files, args.calibration_table, args.verbose, onnx_only=onnx_only, opset=args.opset)
         if onnx_only:
             with open(args.export, 'wb') as out:
                 out.write(exported)

--- a/retinanet/model.py
+++ b/retinanet/model.py
@@ -203,25 +203,26 @@ class Model(nn.Module):
 
         return model, state
 
-    def export(self, size, batch, precision, calibration_files, calibration_table, verbose, onnx_only=False):
+    def export(self, size, batch, precision, calibration_files, calibration_table, verbose, onnx_only=False, opset=None):
         import torch.onnx.symbolic
 
-        # Override Upsample's ONNX export until new opset is supported
-        @torch.onnx.symbolic.parse_args('v', 'is')
-        def upsample_nearest2d(g, input, output_size):
-            height_scale = float(output_size[-2]) / input.type().sizes()[-2]
-            width_scale = float(output_size[-1]) / input.type().sizes()[-1]
-            return g.op("Upsample", input,
-                scales_f=(1, 1, height_scale, width_scale),
-                mode_s="nearest")
-        torch.onnx.symbolic.upsample_nearest2d = upsample_nearest2d
+        if opset is None or opset < 9:
+            # Override Upsample's ONNX export until new opset is supported
+            @torch.onnx.symbolic.parse_args('v', 'is')
+            def upsample_nearest2d(g, input, output_size):
+                height_scale = float(output_size[-2]) / input.type().sizes()[-2]
+                width_scale = float(output_size[-1]) / input.type().sizes()[-1]
+                return g.op("Upsample", input,
+                    scales_f=(1, 1, height_scale, width_scale),
+                    mode_s="nearest")
+            torch.onnx.symbolic.upsample_nearest2d = upsample_nearest2d
 
         # Export to ONNX
         print('Exporting to ONNX...')
         self.exporting = True
         onnx_bytes = io.BytesIO()
         zero_input = torch.zeros([1, 3, *size]).cuda()
-        torch.onnx.export(self.cuda(), zero_input, onnx_bytes)
+        torch.onnx.export(self.cuda(), zero_input, onnx_bytes, opset_version=None)
         self.exporting = False
 
         if onnx_only:

--- a/retinanet/model.py
+++ b/retinanet/model.py
@@ -222,7 +222,8 @@ class Model(nn.Module):
         self.exporting = True
         onnx_bytes = io.BytesIO()
         zero_input = torch.zeros([1, 3, *size]).cuda()
-        torch.onnx.export(self.cuda(), zero_input, onnx_bytes, opset_version=None)
+        extra_args = { 'opset_version': opset } if opset else {}
+        torch.onnx.export(self.cuda(), zero_input, onnx_bytes, *extra_args)
         self.exporting = False
 
         if onnx_only:


### PR DESCRIPTION
Allow specifying the ONNX export opset version to support recent versions of TensorRT.
This also disables the Upsample symbolic override for pre-9 ONNX export.