### PR TITLE
Add DeepStream3.0 examples

### DIFF
--- a/Dockerfile.deepstream
+++ b/Dockerfile.deepstream
@@ -5,14 +5,11 @@ COPY . /workspace/retinanet-examples/
 RUN apt-get update && apt-get install -y libssl1.0.0  libgstreamer1.0-0    gstreamer1.0-tools   gstreamer1.0-plugins-good   gstreamer1.0-plugins-bad     gstreamer1.0-plugins-ugly  gstreamer1.0-libav   libgstrtspserver-1.0-0   libjansson4 ffmpeg
 
 WORKDIR /root
-RUN git clone https://github.com/edenhill/librdkafka.git
-WORKDIR /root/librdkafka
-RUN /root/librdkafka/configure
-RUN make
-RUN make install
 
-RUN mkdir -p /usr/local/deepstream
-RUN cp /usr/local/lib/librdkafka* /usr/local/deepstream
+RUN git clone https://github.com/edenhill/librdkafka.git /librdkafka && \
+    cd /librdkafka && ./configure && make && make install && \
+    mkdir -p /usr/local/deepstream && \
+    cp /usr/local/lib/librdkafka* /usr/local/deepstream
 
 COPY extras/deepstream/DeepStream_Release/binaries.tbz2  \
      extras/deepstream/DeepStream_Release/LicenseAgreement.pdf  \
@@ -36,14 +33,10 @@ ENV NVIDIA_DRIVER_CAPABILITIES $NVIDIA_DRIVER_CAPABILITIES,video
 
 RUN ln -sf /usr/lib/x86_64-linux-gnu/libnvcuvid.so.1 /usr/lib/x86_64-linux-gnu/libnvcuvid.so
 
-
 RUN pip install --no-cache-dir -e /workspace/retinanet-examples
 
-RUN mkdir /workspace/retinanet-examples/extras/deepstream/deepstream-sample/build
-
-WORKDIR /workspace/retinanet-examples/extras/deepstream/deepstream-sample/build
-
-RUN cmake -DDeepStream_DIR=/root/DeepStream_Release ..
-RUN make
+RUN mkdir /workspace/retinanet-examples/extras/deepstream/deepstream-sample/build && \
+    cd /workspace/retinanet-examples/extras/deepstream/deepstream-sample/build && \
+    cmake -DDeepStream_DIR=/root/DeepStream_Release .. && make
 
 WORKDIR /workspace/retinanet-examples/extras/deepstream

--- a/Dockerfile.deepstream
+++ b/Dockerfile.deepstream
@@ -1,0 +1,49 @@
+FROM nvcr.io/nvidia/pytorch:19.02-py3
+
+COPY . /workspace/retinanet-examples/
+
+RUN apt-get update && apt-get install -y libssl1.0.0  libgstreamer1.0-0    gstreamer1.0-tools   gstreamer1.0-plugins-good   gstreamer1.0-plugins-bad     gstreamer1.0-plugins-ugly  gstreamer1.0-libav   libgstrtspserver-1.0-0   libjansson4 ffmpeg
+
+WORKDIR /root
+RUN git clone https://github.com/edenhill/librdkafka.git
+WORKDIR /root/librdkafka
+RUN /root/librdkafka/configure
+RUN make
+RUN make install
+
+RUN mkdir -p /usr/local/deepstream
+RUN cp /usr/local/lib/librdkafka* /usr/local/deepstream
+
+COPY extras/deepstream/DeepStream_Release/binaries.tbz2  \
+     extras/deepstream/DeepStream_Release/LicenseAgreement.pdf  \
+     extras/deepstream/DeepStream_Release/README \
+     /root/DeepStream_Release/
+
+RUN cd /root/DeepStream_Release && \
+    tar -xvf binaries.tbz2 -C /
+
+# config files + sample apps
+COPY extras/deepstream/DeepStream_Release/samples  \
+     /root/DeepStream_Release/samples
+
+COPY extras/deepstream/DeepStream_Release/sources \
+     /root/DeepStream_Release/sources
+
+RUN  chmod u+x /root/DeepStream_Release/sources/tools/nvds_logger/setup_nvds_logger.sh
+
+# To get video driver libraries at runtime (libnvidia-encode.so/libnvcuvid.so)
+ENV NVIDIA_DRIVER_CAPABILITIES $NVIDIA_DRIVER_CAPABILITIES,video
+
+RUN ln -sf /usr/lib/x86_64-linux-gnu/libnvcuvid.so.1 /usr/lib/x86_64-linux-gnu/libnvcuvid.so
+
+
+RUN pip install --no-cache-dir -e /workspace/retinanet-examples
+
+RUN mkdir /workspace/retinanet-examples/extras/deepstream/deepstream-sample/build
+
+WORKDIR /workspace/retinanet-examples/extras/deepstream/deepstream-sample/build
+
+RUN cmake -DDeepStream_DIR=/root/DeepStream_Release ..
+RUN make
+
+WORKDIR /workspace/retinanet-examples/extras/deepstream

--- a/extras/deepstream/README.md
+++ b/extras/deepstream/README.md
@@ -1,0 +1,95 @@
+# Deploying RetinaNet in DeepStream 3.0
+
+This shows how to export a trained RetinaNet model to TensorRT and deploy it in a video analytics application using NVIDIA DeepStream 3.0.
+
+## Prerequisites
+* A GPU supported by DeepStream: Jetson Xavier, Tesla P4/P40/V100/T4
+* Download DeepStream 3.0 SDK from the NVIDIA [DeepStream 3.0](https://developer.nvidia.com/deepstream-sdk) website.
+    * **Note**: DeepStream 3.0 requires CUDA 10, cuDNN 7.3, and TensorRT 5.0. 
+* A trained PyTorch RetinaNet model.
+* One or more video files in .mp4 format.
+
+
+## Setup instructions for Tesla GPUs
+1.) First, ensure that DeepStream 3.0 SDK for Tesla is downloaded to this directory: `DeepStreamSDK-Tesla-v3.0.tbz2`
+
+2.) Unpack the DeepStream 3.0 SDK for Tesla:
+```
+tar -xvf DeepStreamSDK-Tesla-v3.0-tbz2 -C DeepStream_Release/
+```
+
+3.) We strongly recommend using the provided Dockerfile to configure the environment for Tesla GPUs.
+```
+docker build -f retinanet-examples/Dockerfile.deepstream -t ds_retinanet:latest 
+docker run --runtime=nvidia -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,video -it \
+    --rm --ipc=host -v <dir containing your data>:/data ds_retinanet:latest
+```
+
+4.) Finally, export your trained PyTorch RetinaNet model to TensorRT per the [INFERENCE](https://github.com/NVIDIA/retinanet-examples/blob/master/INFERENCE.md) instructions:
+```
+retinanet export <PyTorch model> <engine> --opset 8 --batch n
+
+OR
+
+retinanet export <PyTorch model> <engine> --opset 8 --int8 --calibration-images <example images> --batch n
+```
+
+## Setup instructions for Jetson Xavier
+1.) First, flash Jetson Xavier with [Jetpack 4.1.1](https://developer.nvidia.com/embedded/jetpack-4-1-1)
+
+2.) Install additional DeepStream dependencies:
+```
+sudo apt install \
+    libssl1.0.0 \
+    libgstreamer1.0-0 \
+    gstreamer1.0-tools \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    libgstrtspserver-1.0-0 \
+    libjansson4=2.11-1
+    librdkafka1=0.11.3-1build1
+```
+3.) Download DeepStream 3.0 SDK for Jetson Xavier onto your device: `DeepStreamSDK-Jetson-3.0_EA_beta5.0.tbz2`
+
+4.) Unpack DeepStream 3.0 SDK for Jetson Xavier:
+```
+tar -xpvf DeepStreamSDK-Jetson-3.0_EA_beta5.0.tbz2
+
+cd deepstream_sdk_on_jetson/ && \
+   sudo tar -xvf binaries.tbz2 -C / && \ 
+   ldconfig
+```
+
+5.) Export trained PyTorch RetinaNet model using the [cppapi sample code](https://github.com/NVIDIA/retinanet-examples/tree/master/extras/cppapi#running)
+
+
+## Preparing the DeepStream config file:
+We have included two example DeepStream config files in `deepstream-sample`.
+- `ds_config_1vids.txt`: Performs detection on a single video, using the detector specified by `infer_config_batch1.txt`.
+- `ds_config_8vids.txt`: Performs detection on multiple video streams simultaneously, using the detector specified by `infer_config_batch8.txt`. Frames from each video are combined into a single batch and passed to the detector for inference.
+
+The `ds_config_*` files are DeepStream config files. They describe the overall processing. `infer_config_*` files define the individual detectors, which can be chained in series.
+
+Before they can be used, these config files must be modified to specify the correct paths to the input and output videos files, and the TensorRT engines.
+
+**Input files** are specified in the deepstream config files by the `uri=file://<path>` parameter.
+
+**Output files** are specified in the deepstream config files by the `output-file=<path>` parameter.
+
+**TensorRT engines** are specified in both the DeepStream config files, and also the detector config files, by the `model-engine-file=<path>` parameters. 
+
+
+## Run deepstream-app
+Once all of the config files have been modified, launch the DeepStream application: 
+```
+LD_PRELOAD=<your_local_path>/retinanet-examples/extras/deepstream/build/libnvdsparsebbox_retinanet.so \
+    deepstream-app -c <config file>
+```
+
+## Convert output video file to mp4
+You can convert the outputted `.mkv` file to `.mp4` using `ffmpeg`.
+```
+ffmpeg -i /data/output/file1.mkv -c copy /data/output/file2.mp4
+```

--- a/extras/deepstream/README.md
+++ b/extras/deepstream/README.md
@@ -20,7 +20,7 @@ tar -xvf DeepStreamSDK-Tesla-v3.0-tbz2 -C DeepStream_Release/
 
 3.) We strongly recommend using the provided Dockerfile to configure the environment for Tesla GPUs.
 ```
-docker build -f retinanet-examples/Dockerfile.deepstream -t ds_retinanet:latest 
+docker build -f <your_path>/retinanet-examples/Dockerfile.deepstream -t ds_retinanet:latest <your_path>/retinanet-examples
 docker run --runtime=nvidia -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,video -it \
     --rm --ipc=host -v <dir containing your data>:/data ds_retinanet:latest
 ```

--- a/extras/deepstream/README.md
+++ b/extras/deepstream/README.md
@@ -59,10 +59,15 @@ tar -xpvf DeepStreamSDK-Jetson-3.0_EA_beta5.0.tbz2
 
 cd deepstream_sdk_on_jetson/ && \
    sudo tar -xvf binaries.tbz2 -C / && \ 
-   ldconfig
+   sudo ldconfig
 ```
 
-5.) Export trained PyTorch RetinaNet model using the [cppapi sample code](https://github.com/NVIDIA/retinanet-examples/tree/master/extras/cppapi#running)
+5.) Export trained PyTorch RetinaNet model to ONNX on your host system (i.e. not on your Jetson), specifying (`--opset 8`):
+```
+   retinanet export model.pth model.onnx --opset 8
+```
+
+5.) Copy ONNX RetinaNet model to Jetson Xavier, and export to TensorRT using the [cppapi sample code](https://github.com/NVIDIA/retinanet-examples/tree/master/extras/cppapi#running)
 
 
 ## Preparing the DeepStream config file:
@@ -80,6 +85,7 @@ Before they can be used, these config files must be modified to specify the corr
 
 **TensorRT engines** are specified in both the DeepStream config files, and also the detector config files, by the `model-engine-file=<path>` parameters. 
 
+On Xavier, you can optionally set `enable=1` to `[sink1]` in `ds_config_*` files to display the processed video stream.
 
 ## Run deepstream-app
 Once all of the config files have been modified, launch the DeepStream application: 

--- a/extras/deepstream/deepstream-sample/CMakeLists.txt
+++ b/extras/deepstream/deepstream-sample/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5.1)
+
+project(deepstream-retinanet)
+enable_language(CXX)
+include(FindCUDA)
+
+set(CMAKE_CXX_STANDARD 11)
+find_package(CUDA REQUIRED)
+
+if(DEFINED TensorRT_DIR)
+  include_directories("${TensorRT_DIR}/include")
+  link_directories("${TensorRT_DIR}/lib")
+endif(DEFINED TensorRT_DIR)
+if(DEFINED DeepStream_DIR)
+  include_directories("${DeepStream_DIR}/sources/includes")
+endif(DEFINED DeepStream_DIR)
+include_directories(${CUDA_INCLUDE_DIRS})
+
+cuda_add_library(nvdsparsebbox_retinanet SHARED
+  ../../../csrc/cuda/decode.h
+  ../../../csrc/cuda/decode.cu
+  ../../../csrc/cuda/nms.h
+  ../../../csrc/cuda/nms.cu
+  ../../../csrc/cuda/utils.h
+  ../../../csrc/engine.cpp
+  nvdsparsebbox_retinanet.cpp
+  OPTIONS -arch sm_60 -std=c++11 --expt-extended-lambda
+)
+target_link_libraries(nvdsparsebbox_retinanet ${CUDA_LIBRARIES} nvinfer nvinfer_plugin nvonnxparser)

--- a/extras/deepstream/deepstream-sample/CMakeLists.txt
+++ b/extras/deepstream/deepstream-sample/CMakeLists.txt
@@ -16,6 +16,10 @@ if(DEFINED DeepStream_DIR)
 endif(DEFINED DeepStream_DIR)
 include_directories(${CUDA_INCLUDE_DIRS})
 
+if(NOT DEFINED ARCH)
+  set(ARCH "sm_70")
+endif(NOT DEFINED ARCH)
+
 cuda_add_library(nvdsparsebbox_retinanet SHARED
   ../../../csrc/cuda/decode.h
   ../../../csrc/cuda/decode.cu
@@ -24,6 +28,6 @@ cuda_add_library(nvdsparsebbox_retinanet SHARED
   ../../../csrc/cuda/utils.h
   ../../../csrc/engine.cpp
   nvdsparsebbox_retinanet.cpp
-  OPTIONS -arch sm_60 -std=c++11 --expt-extended-lambda
+  OPTIONS -arch ${ARCH} -std=c++11 --expt-extended-lambda
 )
 target_link_libraries(nvdsparsebbox_retinanet ${CUDA_LIBRARIES} nvinfer nvinfer_plugin nvonnxparser)

--- a/extras/deepstream/deepstream-sample/ds_config_1vid.txt
+++ b/extras/deepstream/deepstream-sample/ds_config_1vid.txt
@@ -48,6 +48,16 @@ bitrate=80000000
 output-file=<path>
 source-id=0
 
+[sink1]
+enable=0
+#Type - 1=FakeSink 2=EglSink 3=File
+type=2
+sync=1
+source-id=0
+gpu-id=0
+cuda-memory-type=1
+
+
 [osd]
 enable=1
 gpu-id=0

--- a/extras/deepstream/deepstream-sample/ds_config_1vid.txt
+++ b/extras/deepstream/deepstream-sample/ds_config_1vid.txt
@@ -1,0 +1,73 @@
+# Copyright (c) 2018 NVIDIA Corporation.  All rights reserved.
+#
+# NVIDIA Corporation and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA Corporation is strictly prohibited.
+
+[application]
+enable-perf-measurement=1
+perf-measurement-interval-sec=1
+
+[tiled-display]
+enable=0
+rows=1
+columns=1
+width=1280
+height=720
+gpu-id=0
+
+[source0]
+enable=1
+type=2
+num-sources=1
+uri=file://<path>
+gpu-id=0
+
+[streammux]
+gpu-id=0
+batch-size=1
+batched-push-timeout=-1
+## Set muxer output width and height
+width=1280
+height=720
+cuda-memory-type=1
+enable-padding=1
+
+[sink0]
+enable=1
+type=3
+#1=mp4 2=mkv
+container=1
+#1=h264 2=h265 3=mpeg4
+## only SW mpeg4 is supported right now.
+codec=3
+sync=1
+bitrate=80000000
+output-file=<path>
+source-id=0
+
+[osd]
+enable=1
+gpu-id=0
+border-width=2
+text-size=12
+text-color=1;1;1;1;
+text-bg-color=0.3;0.3;0.3;1
+font=Arial
+show-clock=0
+clock-x-offset=800
+clock-y-offset=820
+clock-text-size=12
+clock-color=1;0;0;0
+
+[primary-gie]
+enable=1
+gpu-id=0
+batch-size=1
+gie-unique-id=1
+interval=0
+labelfile-path=labels_coco.txt
+model-engine-file=<path>
+config-file=infer_config_batch1.txt

--- a/extras/deepstream/deepstream-sample/ds_config_8vid.txt
+++ b/extras/deepstream/deepstream-sample/ds_config_8vid.txt
@@ -1,0 +1,85 @@
+# Copyright (c) 2018 NVIDIA Corporation.  All rights reserved.
+#
+# NVIDIA Corporation and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA Corporation is strictly prohibited.
+
+[application]
+enable-perf-measurement=1
+perf-measurement-interval-sec=5
+
+[tiled-display]
+enable=1
+rows=2
+columns=4
+width=1280
+height=720
+gpu-id=0
+cuda-memory-type=1
+
+[source0]
+enable=1
+type=3
+num-sources=4
+uri=file://<path>
+gpu-id=0
+cuda-memory-type=1
+
+[source1]
+enable=1
+type=3
+num-sources=4
+uri=file://<path>
+gpu-id=0
+cuda-memory-type=1
+
+[streammux]
+gpu-id=0
+batched-push-timeout=-1
+## Set muxer output width and height
+width=1280
+height=720
+cuda-memory-type=1
+enable-padding=1
+batch-size=8
+
+[sink0]
+enable=1
+type=3
+#1=mp4 2=mkv
+container=1
+#1=h264 2=h265 3=mpeg4
+## only SW mpeg4 is supported right now.
+codec=3
+sync=0
+bitrate=32000000
+output-file=<path>
+source-id=0
+cuda-memory-type=1
+
+[osd]
+enable=1
+gpu-id=0
+border-width=2
+text-size=12
+text-color=1;1;1;1;
+text-bg-color=0.3;0.3;0.3;1
+font=Arial
+show-clock=0
+clock-x-offset=800
+clock-y-offset=820
+clock-text-size=12
+clock-color=1;0;0;0
+
+[primary-gie]
+enable=1
+gpu-id=0
+batch-size=8
+gie-unique-id=1
+interval=0
+labelfile-path=labels_coco.txt
+model-engine-file=<path>
+config-file=infer_config_batch8.txt
+cuda-memory-type=1

--- a/extras/deepstream/deepstream-sample/ds_config_8vid.txt
+++ b/extras/deepstream/deepstream-sample/ds_config_8vid.txt
@@ -59,6 +59,16 @@ output-file=<path>
 source-id=0
 cuda-memory-type=1
 
+[sink1]
+enable=0
+#Type - 1=FakeSink 2=EglSink 3=File
+type=2
+sync=1
+source-id=0
+gpu-id=0
+cuda-memory-type=1
+
+
 [osd]
 enable=1
 gpu-id=0

--- a/extras/deepstream/deepstream-sample/infer_config_batch1.txt
+++ b/extras/deepstream/deepstream-sample/infer_config_batch1.txt
@@ -1,0 +1,88 @@
+# Copyright (c) 2018 NVIDIA Corporation.  All rights reserved.
+# NVIDIA Corporation and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA Corporation is strictly prohibited.
+
+# Following properties are mandatory when engine files are not specified:
+#   int8-calib-file(Only in INT8)
+#   Caffemodel mandatory properties: model-file, proto-file, output-blob-names
+#   UFF: uff-file, input-dims, uff-input-blob-name, output-blob-names
+#   ONNX: onnx-file
+#
+# Mandatory properties for detectors:
+#   parse-func, num-detected-classes,
+#   custom-lib-path (when parse-func=0 i.e. custom),
+#   parse-bbox-func-name (when parse-func=0)
+#
+# Optional properties for detectors:
+#   enable-dbscan(Default=false), interval(Primary mode only, Default=0)
+#
+# Mandatory properties for classifiers:
+#   classifier-threshold, is-classifier
+#
+# Optional properties for classifiers:
+#   classifier-async-mode(Secondary mode only, Default=false)
+#
+# Optional properties in secondary mode:
+#   operate-on-gie-id(Default=0), operate-on-class-ids(Defaults to all classes),
+#   input-object-min-width, input-object-min-height, input-object-max-width,
+#   input-object-max-height
+#
+# Following properties are always recommended:
+#   batch-size(Default=1)
+#
+# Other optional properties:
+#   net-scale-factor(Default=1), network-mode(Default=0 i.e FP32),
+#   model-color-format(Default=0 i.e. RGB) model-engine-file, labelfile-path,
+#   mean-file, gie-unique-id(Default=0), offsets, gie-mode (Default=1 i.e. primary),
+#   custom-lib-path, network-mode(Default=0 i.e FP32)
+#
+# The values in the config file are overridden by values set through GObject
+# properties.
+
+[property]
+gpu-id=0
+net-scale-factor=0.017352074
+offsets=123.675;116.28;103.53
+model-engine-file=<path>
+labelfile-path=labels_coco.txt
+batch-size=1
+## 0=FP32, 1=INT8, 2=FP16 mode
+network-mode=2
+num-detected-classes=80
+interval=0
+gie-unique-id=1
+parse-func=0
+is-classifier=0
+output-blob-names=boxes;scores;classes
+parse-bbox-func-name=NvDsInferParseCustomRetinaNet
+custom-lib-path=build/libnvdsparsebbox_retinanet.so
+#enable-dbscan=1
+
+
+[class-attrs-all]
+threshold=0.5
+group-threshold=0
+## Set eps=0.7 and minBoxes for enable-dbscan=1
+#eps=0.2
+##minBoxes=3
+#roi-top-offset=0
+#roi-bottom-offset=0
+detected-min-w=4
+detected-min-h=4
+#detected-max-w=0
+#detected-max-h=0
+
+## Per class configuration
+#[class-attrs-2]
+#threshold=0.6
+#eps=0.5
+#group-threshold=3
+#roi-top-offset=20
+#roi-bottom-offset=10
+#detected-min-w=40
+#detected-min-h=40
+#detected-max-w=400
+#detected-max-h=800

--- a/extras/deepstream/deepstream-sample/infer_config_batch1.txt
+++ b/extras/deepstream/deepstream-sample/infer_config_batch1.txt
@@ -57,7 +57,7 @@ gie-unique-id=1
 parse-func=0
 is-classifier=0
 output-blob-names=boxes;scores;classes
-parse-bbox-func-name=NvDsInferParseCustomRetinaNet
+parse-bbox-func-name=NvDsInferParseRetinaNet
 custom-lib-path=build/libnvdsparsebbox_retinanet.so
 #enable-dbscan=1
 

--- a/extras/deepstream/deepstream-sample/infer_config_batch8.txt
+++ b/extras/deepstream/deepstream-sample/infer_config_batch8.txt
@@ -58,7 +58,7 @@ gie-unique-id=1
 parse-func=0
 is-classifier=0
 output-blob-names=boxes;scores;classes
-parse-bbox-func-name=NvDsInferParseCustomRetinaNet
+parse-bbox-func-name=NvDsInferParseRetinaNet
 custom-lib-path=build/libnvdsparsebbox_retinanet.so
 #enable-dbscan=1
 

--- a/extras/deepstream/deepstream-sample/infer_config_batch8.txt
+++ b/extras/deepstream/deepstream-sample/infer_config_batch8.txt
@@ -1,0 +1,89 @@
+# Copyright (c) 2018 NVIDIA Corporation.  All rights reserved.
+# NVIDIA Corporation and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA Corporation is strictly prohibited.
+
+# Following properties are mandatory when engine files are not specified:
+#   int8-calib-file(Only in INT8)
+#   Caffemodel mandatory properties: model-file, proto-file, output-blob-names
+#   UFF: uff-file, input-dims, uff-input-blob-name, output-blob-names
+#   ONNX: onnx-file
+#
+# Mandatory properties for detectors:
+#   parse-func, num-detected-classes,
+#   custom-lib-path (when parse-func=0 i.e. custom),
+#   parse-bbox-func-name (when parse-func=0)
+#
+# Optional properties for detectors:
+#   enable-dbscan(Default=false), interval(Primary mode only, Default=0)
+#
+# Mandatory properties for classifiers:
+#   classifier-threshold, is-classifier
+#
+# Optional properties for classifiers:
+#   classifier-async-mode(Secondary mode only, Default=false)
+#
+# Optional properties in secondary mode:
+#   operate-on-gie-id(Default=0), operate-on-class-ids(Defaults to all classes),
+#   input-object-min-width, input-object-min-height, input-object-max-width,
+#   input-object-max-height
+#
+# Following properties are always recommended:
+#   batch-size(Default=1)
+#
+# Other optional properties:
+#   net-scale-factor(Default=1), network-mode(Default=0 i.e FP32),
+#   model-color-format(Default=0 i.e. RGB) model-engine-file, labelfile-path,
+#   mean-file, gie-unique-id(Default=0), offsets, gie-mode (Default=1 i.e. primary),
+#   custom-lib-path, network-mode(Default=0 i.e FP32)
+#
+# The values in the config file are overridden by values set through GObject
+# properties.
+
+[property]
+gpu-id=0
+net-scale-factor=0.017352074
+offsets=123.675;116.28;103.53
+model-engine-file=<path>
+labelfile-path=labels_coco.txt
+#int8-calib-file=cal_trt4.bin
+batch-size=8
+## 0=FP32, 1=INT8, 2=FP16 mode
+network-mode=2
+num-detected-classes=80
+interval=0
+gie-unique-id=1
+parse-func=0
+is-classifier=0
+output-blob-names=boxes;scores;classes
+parse-bbox-func-name=NvDsInferParseCustomRetinaNet
+custom-lib-path=build/libnvdsparsebbox_retinanet.so
+#enable-dbscan=1
+
+
+[class-attrs-all]
+threshold=0.5
+group-threshold=0
+## Set eps=0.7 and minBoxes for enable-dbscan=1
+#eps=0.2
+##minBoxes=3
+#roi-top-offset=0
+#roi-bottom-offset=0
+detected-min-w=4
+detected-min-h=4
+#detected-max-w=0
+#detected-max-h=0
+
+## Per class configuration
+#[class-attrs-2]
+#threshold=0.6
+#eps=0.5
+#group-threshold=3
+#roi-top-offset=20
+#roi-bottom-offset=10
+#detected-min-w=40
+#detected-min-h=40
+#detected-max-w=400
+#detected-max-h=800

--- a/extras/deepstream/deepstream-sample/labels_coco.txt
+++ b/extras/deepstream/deepstream-sample/labels_coco.txt
@@ -1,0 +1,80 @@
+person
+bicycle
+car
+motorcycle
+airplane
+bus
+train
+truck
+boat
+traffic light
+fire hydrant
+stop sign
+parking meter
+bench
+bird
+cat
+dog
+horse
+sheep
+cow
+elephant
+bear
+zebra
+giraffe
+backpack
+umbrella
+handbag
+tie
+suitcase
+frisbee
+skis
+snowboard
+sports ball
+kite
+baseball bat
+baseball glove
+skateboard
+surfboard
+tennis racket
+bottle
+wine glass
+cup
+fork
+knife
+spoon
+bowl
+banana
+apple
+sandwich
+orange
+broccoli
+carrot
+hot dog
+pizza
+donut
+cake
+chair
+couch
+potted plant
+bed
+dining table
+toilet
+tv
+laptop
+mouse
+remote
+keyboard
+cell phone
+microwave
+oven
+toaster
+sink
+refrigerator
+book
+clock
+vase
+scissors
+teddy bear
+hair drier
+toothbrush

--- a/extras/deepstream/deepstream-sample/nvdsparsebbox_retinanet.cpp
+++ b/extras/deepstream/deepstream-sample/nvdsparsebbox_retinanet.cpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA Corporation and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distridbution of this software and related documentation without an express
+ * license agreement from NVIDIA Corporation is strictly prohibited.
+ *
+ */
+
+#include <cstring>
+#include <iostream>
+#include "nvdsinfer_custom_impl.h"
+
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+
+/* This is a sample bounding box parsing function for the sample Resnet10
+ * detector model provided with the SDK. */
+
+/* C-linkage to prevent name-mangling */
+extern "C"
+bool NvDsInferParseCustomRetinaNet (std::vector<NvDsInferLayerInfo> const &outputLayersInfo,
+        NvDsInferNetworkInfo  const &networkInfo,
+        NvDsInferParseDetectionParams const &detectionParams,
+        std::vector<NvDsInferParseObjectInfo> &objectList)
+{
+  // std::cout << "DEBUG: Entering function" << std::endl;
+  static int bboxLayerIndex = -1;
+  static int classesLayerIndex = -1;
+  static int scoresLayerIndex = -1;
+  static NvDsInferDimsCHW scoresLayerDims;
+  int numDetsToParse;
+
+  /* Find the bbox layer */
+  if (bboxLayerIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "boxes") == 0) {
+        bboxLayerIndex = i;
+        break;
+      }
+    }
+    if (bboxLayerIndex == -1) {
+    std::cerr << "Could not find bbox layer buffer while parsing" << std::endl;
+    return false;
+    }
+  }
+
+  /* Find the scores layer */
+  if (scoresLayerIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "scores") == 0) {
+        scoresLayerIndex = i;
+        getDimsCHWFromDims(scoresLayerDims, outputLayersInfo[i].dims);
+        break;
+      }
+    }
+    if (scoresLayerIndex == -1) {
+    std::cerr << "Could not find scores layer buffer while parsing" << std::endl;
+    return false;
+    }
+  }
+
+  /* Find the classes layer */
+  if (classesLayerIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "classes") == 0) {
+        classesLayerIndex = i;
+        break;
+      }
+    }
+    if (classesLayerIndex == -1) {
+    std::cerr << "Could not find classes layer buffer while parsing" << std::endl;
+    return false;
+    }
+  }  
+
+  
+  /* Calculate the number of detections to parse */
+  numDetsToParse = scoresLayerDims.c;
+  //std::cout << "DEBUG: Number of detections: " << numDetsToParse << std::endl;
+
+  float *bboxes = (float *) outputLayersInfo[bboxLayerIndex].buffer;
+  float *classes = (float *) outputLayersInfo[classesLayerIndex].buffer;
+  float *scores = (float *) outputLayersInfo[scoresLayerIndex].buffer;
+  // std::cout << "DEBUG: outputLayersInfo[scoresLayerIndex].buffer: " << outputLayersInfo[scoresLayerIndex].buffer << std::endl;
+  
+  for (int indx = 0; indx < numDetsToParse; indx++)
+  {
+    float outputX1 = bboxes[indx * 4];
+    float outputY1 = bboxes[indx * 4 + 1];
+    float outputX2 = bboxes[indx * 4 + 2];
+    float outputY2 = bboxes[indx * 4 + 3];
+    float this_class = classes[indx];
+    float this_score = scores[indx];
+    float threshold = detectionParams.perClassThreshold[this_class];
+    
+    if (this_score >= threshold)
+    {
+      NvDsInferParseObjectInfo object;
+      
+      object.classId = this_class;
+      object.detectionConfidence = this_score;
+
+      object.left = outputX1;
+      object.top = outputY1;
+      object.width = outputX2 - outputX1;
+      object.height = outputY2 - outputY1;
+
+      objectList.push_back(object);
+    }
+  }
+  //std::cout << "Returning from function" <<std::endl;
+  return true;
+}
+
+/* Check that the custom function has been defined correctly */
+CHECK_CUSTOM_PARSE_FUNC_PROTOTYPE(NvDsInferParseCustomRetinaNet);

--- a/extras/deepstream/deepstream-sample/nvdsparsebbox_retinanet.cpp
+++ b/extras/deepstream/deepstream-sample/nvdsparsebbox_retinanet.cpp
@@ -20,12 +20,11 @@
 
 /* C-linkage to prevent name-mangling */
 extern "C"
-bool NvDsInferParseCustomRetinaNet (std::vector<NvDsInferLayerInfo> const &outputLayersInfo,
+bool NvDsInferParseRetinaNet (std::vector<NvDsInferLayerInfo> const &outputLayersInfo,
         NvDsInferNetworkInfo  const &networkInfo,
         NvDsInferParseDetectionParams const &detectionParams,
         std::vector<NvDsInferParseObjectInfo> &objectList)
 {
-  // std::cout << "DEBUG: Entering function" << std::endl;
   static int bboxLayerIndex = -1;
   static int classesLayerIndex = -1;
   static int scoresLayerIndex = -1;
@@ -78,12 +77,10 @@ bool NvDsInferParseCustomRetinaNet (std::vector<NvDsInferLayerInfo> const &outpu
   
   /* Calculate the number of detections to parse */
   numDetsToParse = scoresLayerDims.c;
-  //std::cout << "DEBUG: Number of detections: " << numDetsToParse << std::endl;
 
   float *bboxes = (float *) outputLayersInfo[bboxLayerIndex].buffer;
   float *classes = (float *) outputLayersInfo[classesLayerIndex].buffer;
   float *scores = (float *) outputLayersInfo[scoresLayerIndex].buffer;
-  // std::cout << "DEBUG: outputLayersInfo[scoresLayerIndex].buffer: " << outputLayersInfo[scoresLayerIndex].buffer << std::endl;
   
   for (int indx = 0; indx < numDetsToParse; indx++)
   {
@@ -110,9 +107,8 @@ bool NvDsInferParseCustomRetinaNet (std::vector<NvDsInferLayerInfo> const &outpu
       objectList.push_back(object);
     }
   }
-  //std::cout << "Returning from function" <<std::endl;
   return true;
 }
 
 /* Check that the custom function has been defined correctly */
-CHECK_CUSTOM_PARSE_FUNC_PROTOTYPE(NvDsInferParseCustomRetinaNet);
+CHECK_CUSTOM_PARSE_FUNC_PROTOTYPE(NvDsInferParseRetinaNet);


### PR DESCRIPTION
PR to add DeepStream3.0 examples to retinanet-examples/extras/deepstream

TODO:
* Test README instructions on Volta & Turing Tesla GPUs
* Ensure workflow on Jetson Xavier works as advertised
* Update main README to include DeepStream and pointer to DeepStream specific README