### PR TITLE
Fix incorrect order of h and w (#55)

### DIFF
--- a/extras/cppapi/infer.cpp
+++ b/extras/cppapi/infer.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
 	cout << "Preparing data..." << endl;
 	auto image = imread(argv[2], IMREAD_COLOR);
 	auto inputSize = engine.getInputSize();
-	cv::resize(image, image, Size(inputSize[0], inputSize[1]));
+	cv::resize(image, image, Size(inputSize[1], inputSize[0]));
         cv::Mat pixels;
         image.convertTo(pixels, CV_32FC3, 1.0 / 255, 0);
 


### PR DESCRIPTION
The output of `vector<int> getInputSize();` ([L57](https://github.com/yashnv/retinanet-examples/blob/master/csrc/engine.h#L57)) is **(h, w)** and input to argument **Size** of **cv::resize** ([L31](https://github.com/yashnv/retinanet-examples/blob/master/extras/cppapi/infer.cpp#L31)) is **(w, h)** as per `<opencv2/core/types.hpp>`:
```template<typename _Tp> inline
Size_<_Tp>::Size_(_Tp _width, _Tp _height)
    : width(_width), height(_height) {}```