### PR TITLE
Update COCO json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ When converting the annotations from your own dataset into JSON, the following e
         "id" : int,
         "image_id" : int, 
         "category_id" : int,
-        "bbox" : [x, y, w, h]
+        "bbox" : [x, y, w, h],
+        "iscrowd": 0,
+        "area": w * h
     }],
     "categories": [{
         "id" : int


### PR DESCRIPTION
I converted my own dataset to the COCO format. When I tried to fine-tune with it, I received errors from pycocotools/cocoeval.py. One of the errors was fixed by the key "iscrowd" which should always be 0 because we're using bounding boxes. The other one was the "area" key which should be width * height. Both values are to the best of my knowledge. Maybe pycocotools made breaking changes or I've set some options wrong. In any case, the suggested changes worked for me.