### PR TITLE
Add result arg to infer

### DIFF
--- a/extras/cppapi/README.md
+++ b/extras/cppapi/README.md
@@ -45,7 +45,12 @@ You can also export the ONNX core model to an INT8 TensorRT engine if you have a
 export{.exe} model.onnx engine.plan INT8CalibrationTable
 ```
 
-Run a test inference:
+Run a test inference (result will be saved to "detections.png"):
+```bash
+infer{.exe} engine.plan image.jpg
+```
+
+You can also indicate the path where result will be saved to:
 ```bash
 infer{.exe} engine.plan image.jpg result.png
 ```

--- a/extras/cppapi/README.md
+++ b/extras/cppapi/README.md
@@ -47,7 +47,7 @@ export{.exe} model.onnx engine.plan INT8CalibrationTable
 
 Run a test inference:
 ```bash
-infer{.exe} engine.plan image.jpg
+infer{.exe} engine.plan image.jpg result.png
 ```
 
 Note: make sure the TensorRT, CuDNN and OpenCV libraries are available in your environment and path.

--- a/extras/cppapi/infer.cpp
+++ b/extras/cppapi/infer.cpp
@@ -17,8 +17,8 @@ using namespace std;
 using namespace cv;
 
 int main(int argc, char *argv[]) {
-	if (argc != 3) {
-		cerr << "Usage: " << argv[0] << " engine.plan image.jpg" << endl;
+	if (argc != 4) {
+		cerr << "Usage: " << argv[0] << " engine.plan image.jpg result.png" << endl;
 		return 1;
 	}
 
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Write image
-	imwrite("detections.png", image);
+	imwrite(argv[3], image);
 
 	return 0;
 }

--- a/extras/cppapi/infer.cpp
+++ b/extras/cppapi/infer.cpp
@@ -17,10 +17,6 @@ using namespace std;
 using namespace cv;
 
 int main(int argc, char *argv[]) {
-	if (argc != 4) {
-		cerr << "Usage: " << argv[0] << " engine.plan image.jpg result.png" << endl;
-		return 1;
-	}
 
 	cout << "Loading engine..." << endl;
 	auto engine = retinanet::Engine(argv[1]);
@@ -106,7 +102,9 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Write image
-	imwrite(argv[3], image);
-
+	string out_file = argc == 4 ? string(argv[3]) : "detections.png";
+	cout << "Saving result to " << out_file << endl;
+	imwrite(out_file, image);
+	
 	return 0;
 }


### PR DESCRIPTION
This PR adds a new required argument to `infer.cpp` to indicate where to save the resulting painted image. 